### PR TITLE
Refresh NYSE/other listings and workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,46 +1,33 @@
-name: Update gdp data
+name: Update nyse-other-listings data
 
 on:
-  # Schedule to run daily
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
-  push:
-    branches:
-      - main
-
-  pull_request:
-    branches:
-      - main
-
-  workflow_dispatch: 
+permissions:
+  contents: write
 
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
-
-    if: github.ref == 'refs/heads/main'
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
     - name: Install Python dependencies
       run: |
-          python -m venv venv
-          source venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements.txt
 
     - name: Run scripts
-      run: |
-        source venv/bin/activate
-        python scripts/process.py
+      run: python scripts/process.py
 
     - name: Configure Git
       run: |
@@ -53,7 +40,7 @@ jobs:
     - name: Commit and Push changes
       run: |
         git diff --quiet && echo "No changes to commit" || (
-          git add . &&
+          git add data/ datapackage.json &&
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}" &&
           git push origin main
         )

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,14 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-04
+
+- Re-ran `scripts/process.py` and refreshed:
+  - `data/other-listed.csv`
+  - `data/nyse-listed.csv`
+  - `datapackage.json`
+- Updated GitHub Actions workflow automation:
+  - corrected workflow name,
+  - removed push/PR triggers and kept schedule + manual dispatch,
+  - added explicit `permissions: contents: write`,
+  - upgraded to `actions/checkout@v4` and `actions/setup-python@v5`,
+  - restricted commit scope to data and datapackage outputs.

--- a/data/nyse-listed.csv
+++ b/data/nyse-listed.csv
@@ -77,12 +77,12 @@ AGM.A,Federal Agricultural Mortgage Corporation Common Stock
 AGO,Assured Guaranty Ltd. Common Stock
 AGRO,Adecoagro S.A. Common Shares
 AGX,"Argan, Inc. Common Stock"
-AHH,"Armada Hoffler Properties, Inc. Common Stock"
-AHH$A,"Armada Hoffler Properties, Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock"
 AHL$D,Aspen Insurance Holdings Limited 5.625% Perpetual Non
 AHL$E,"Aspen Insurance Holdings Limited Depositary Shares, each representing a 1/1000th interest in a share of 5.625% Perpetual Non"
 AHL$F,"Aspen Insurance Holdings Limited Depositary Shares, each representing a 1/1,000th Interest in a 7.00% Perpetual Non"
 AHR,"American Healthcare REIT, Inc. Common Stock"
+AHRT,"AH Realty Trust, Inc. Common Stock"
+AHRT$A,"AH Realty Trust, Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock"
 AHT,Ashford Hospitality Trust Inc Common Stock
 AHT$D,Ashford Hospitality Trust Inc 8.45% Series D Cumulative Preferred Stock
 AHT$F,Ashford Hospitality Trust Inc 7.375% Series F Cumulative Preferred Stock
@@ -1057,7 +1057,6 @@ FPI,Farmland Partners Inc. Common Stock
 FPS,"Forgent Power Solutions, Inc. Class A Common Stock"
 FR,"First Industrial Realty Trust, Inc. Common Stock"
 FRA,Blackrock Floating Rate Income Strategies Fund Inc  Common Stock
-FRGE,"Forge Global Holdings, Inc. Common Stock"
 FRO,Frontline Plc Ordinary Shares
 FRT,Federal Realty Investment Trust Common Stock
 FRT$C,"Federal Realty Investment Trust Depositary Shares, each representing a 1/1000th interest in a 5.000% Series C Cumulative Redeemable Preferred Share"
@@ -1146,6 +1145,7 @@ GJT,Synthetic Fixed
 GKOS,Glaukos Corporation Common Stock
 GL,Globe Life Inc. Common Stock
 GL$D,Globe Life Inc. 4.25% Junior Subordinated Debentures due 2061
+GLED.U,"GalaxyEdge Acquisition Corporation Units, each consisting of one Ordinary Share and one Right entitling the holder to receive 1/4th of one ordinary share"
 GLOB,Globant S.A. Common Shares
 GLOP$A,GasLog Partners LP 8.625% Series A Cumulative Redeemable Perpetual Fixed to Floating Rate Preference Units
 GLOP$B,GasLog Partners LP 8.200% Series B Cumulative Redeemable Perpetual Fixed to Floating Rate Preference Units
@@ -1333,7 +1333,7 @@ IDE,"Voya Infrastructure, Industrials and Materials Fund Common Shares of Benefi
 IDT,IDT Corporation Class B Common Stock
 IEX,IDEX Corporation Common Stock
 IFF,"International Flavors & Fragrances, Inc. Common Stock"
-IFN,"India Fund, Inc. (The) Common Stock"
+IFN,"Aberdeen India Fund, Inc. Common Stock"
 IFS,Intercorp Financial Services Inc. Common Shares
 IGA,Voya Global Advantage and Premium Opportunity Fund Common Shares of Beneficial Interest
 IGCB,TCW Corporate Bond ETF
@@ -1446,6 +1446,7 @@ KB,KB Financial Group Inc
 KBDC,"Kayne Anderson BDC, Inc. Common Stock"
 KBH,KB Home Common Stock
 KBR,"KBR, Inc. Common Stock"
+KCAC.U,"Kensington Capital Acquisition Corp. VI Units, each consisting of one Class A ordinary share, one"
 KD,"Kyndryl Holdings, Inc. Common Stock"
 KEN,Kenon Holdings Ltd. Ordinary Shares
 KEP,Korea Electric Power Corporation Common Stock
@@ -2077,6 +2078,7 @@ POR,Portland General Electric Co Common Stock
 POST,"Post Holdings, Inc. Common Stock"
 PPG,"PPG Industries, Inc. Common Stock"
 PPL,PPL Corporation Common Stock
+PPLC,PPL Corporation Corporate Units
 PPT,Putnam Premier Income Trust Common Stock
 PR,Permian Resources Corporation Class A Common Stock
 PRA,ProAssurance Corporation Common Stock
@@ -2155,7 +2157,6 @@ RAMP,"LiveRamp Holdings, Inc. Common Stock"
 RBA,"RB Global, Inc. Common Stock"
 RBC,RBC Bearings Incorporated Common Stock
 RBLX,Roblox Corporation Class A Common Stock
-RBOT,Vicarious Surgical Inc. Class A Common Stock
 RBRK,"Rubrik, Inc. Class A Common Stock"
 RC,Ready Capital Corporation Common Stock
 RC$C,Ready Capital Corporation 6.25% Series C Cumulative Convertible Preferred Stock
@@ -2470,6 +2471,7 @@ STZ,"Constellation Brands, Inc. Common Stock"
 SU,Suncor Energy  Inc. Common Stock
 SUI,"Sun Communities, Inc. Common Stock"
 SUN,Sunoco LP Common Units representing limited partner interests
+SUNB,"Sunbelt Rentals Holdings, Inc. Common Stock"
 SUNC,"SunocoCorp LLC Common Units, representing limited liability company interests"
 SUPV,Grupo Supervielle S.A. American Depositary Shares each Representing five Class B shares
 SUZ,Suzano S.A. American Depositary Shares (each representing One Ordinary Share)
@@ -2602,7 +2604,6 @@ TRTX$C,"TPG RE Finance Trust, Inc. 6.25% Series C Cumulative Redeemable Preferre
 TRU,TransUnion Common Stock
 TRV,"The Travelers Companies, Inc. Common Stock"
 TS,Tenaris S.A. American Depositary Shares
-TSE,Trinseo PLC Ordinary Shares 
 TSI,"TCW Strategic Income Fund, Inc. Common Stock"
 TSI.R,"TCW Strategic Income Fund, Inc. Rights (expiring March 18, 2026) Rights"
 TSLX,"Sixth Street Specialty Lending, Inc. Common Stock"
@@ -2793,6 +2794,7 @@ WH,"Wyndham Hotels & Resorts, Inc. Common Stock "
 WHD,"Cactus, Inc. Class A Common Stock"
 WHG,Westwood Holdings Group Inc Common Stock
 WHR,Whirlpool Corporation Common Stock
+WHR$A,"Whirlpool Corporation Depositary Shares, each representing a 1/20th interest in a share of 8.50% Series A Mandatory Convertible Preferred Stock"
 WIA,Western Asset Inflation
 WINN,Harbor Long
 WIT,Wipro Limited Common Stock

--- a/data/other-listed.csv
+++ b/data/other-listed.csv
@@ -139,13 +139,13 @@ AGRO,Adecoagro S.A. Common Shares,Adecoagro S.A. Common Shares,N,AGRO,N,100.0,N,
 AGRW,Allspring LT Large Growth ETF,Allspring LT Large Growth ETF,P,AGRW,Y,100.0,N,AGRW
 AGX,"Argan, Inc. Common Stock","Argan, Inc. Common Stock",N,AGX,N,100.0,N,AGX
 AGZ,iShares  Agency Bond ETF,iShares  Agency Bond ETF,P,AGZ,Y,100.0,N,AGZ
-AHH,"Armada Hoffler Properties, Inc. Common Stock","Armada Hoffler Properties, Inc. Common Stock",N,AHH,N,100.0,N,AHH
-AHH$A,"Armada Hoffler Properties, Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock","Armada Hoffler Properties, Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock",N,AHHpA,N,100.0,N,AHH-A
 AHL$D,Aspen Insurance Holdings Limited 5.625% Perpetual Non,Aspen Insurance Holdings Limited 5.625% Perpetual Non-Cumulative Preference Shares,N,AHLpD,N,100.0,N,AHL-D
 AHL$E,"Aspen Insurance Holdings Limited Depositary Shares, each representing a 1/1000th interest in a share of 5.625% Perpetual Non","Aspen Insurance Holdings Limited Depositary Shares, each representing a 1/1000th interest in a share of 5.625% Perpetual Non-Cumulative Preference Shares",N,AHLpE,N,100.0,N,AHL-E
 AHL$F,"Aspen Insurance Holdings Limited Depositary Shares, each representing a 1/1,000th Interest in a 7.00% Perpetual Non","Aspen Insurance Holdings Limited Depositary Shares, each representing a 1/1,000th Interest in a 7.00% Perpetual Non-Cumulative Preference Share",N,AHLpF,N,100.0,N,AHL-F
 AHLT,AHL Trend ETF,AHL Trend ETF,P,AHLT,Y,100.0,N,AHLT
 AHR,"American Healthcare REIT, Inc. Common Stock","American Healthcare REIT, Inc. Common Stock",N,AHR,N,100.0,N,AHR
+AHRT,"AH Realty Trust, Inc. Common Stock","AH Realty Trust, Inc. Common Stock",N,AHRT,N,100.0,N,AHRT
+AHRT$A,"AH Realty Trust, Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock","AH Realty Trust, Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock",N,AHRTpA,N,100.0,N,AHRT-A
 AHT,Ashford Hospitality Trust Inc Common Stock,Ashford Hospitality Trust Inc Common Stock,N,AHT,N,100.0,N,AHT
 AHT$D,Ashford Hospitality Trust Inc 8.45% Series D Cumulative Preferred Stock,Ashford Hospitality Trust Inc 8.45% Series D Cumulative Preferred Stock,N,AHTpD,N,100.0,N,AHT-D
 AHT$F,Ashford Hospitality Trust Inc 7.375% Series F Cumulative Preferred Stock,Ashford Hospitality Trust Inc 7.375% Series F Cumulative Preferred Stock,N,AHTpF,N,100.0,N,AHT-F
@@ -644,7 +644,6 @@ BFLB,BufferLABS US Equity Dynamic Buffer ETF,BufferLABS US Equity Dynamic Buffer
 BFLY,"Butterfly Network, Inc. Class A Common Stock","Butterfly Network, Inc. Class A Common Stock",N,BFLY,N,100.0,N,BFLY
 BFOC,FT Vest Bitcoin Strategy Floor15 ETF ,FT Vest Bitcoin Strategy Floor15 ETF - October,P,BFOC,Y,100.0,N,BFOC
 BFOR,Barron's 400 ETF,Barron's 400 ETF,P,BFOR,Y,100.0,N,BFOR
-BFRE,Westwood LBRTY Global Equity ETF,Westwood LBRTY Global Equity ETF,P,BFRE,Y,100.0,N,BFRE
 BFRZ,Innovator Equity Managed 100 Buffer ETF,Innovator Equity Managed 100 Buffer ETF,P,BFRZ,Y,100.0,N,BFRZ
 BFS,"Saul Centers, Inc. Common Stock","Saul Centers, Inc. Common Stock",N,BFS,N,100.0,N,BFS
 BFS$D,"Saul Centers, Inc. Depositary Shares, each representing 1/100th of a share of 6.125% Series D Cumulative Redeemable Preferred Stock","Saul Centers, Inc. Depositary Shares, each representing 1/100th of a share of 6.125% Series D Cumulative Redeemable Preferred Stock",N,BFSpD,N,100.0,N,BFS-D
@@ -1051,7 +1050,7 @@ CELG.R,Bristol,Bristol-Myers Squibb Company Celegne Contingent Value Rights,N,CE
 CELT,Tradr 2X Long CELH Daily ETF,Tradr 2X Long CELH Daily ETF,Z,CELT,Y,100.0,N,CELT
 CEMB,iShares J.P. Morgan EM Corporate Bond ETF,iShares J.P. Morgan EM Corporate Bond ETF,Z,CEMB,Y,100.0,N,CEMB
 CEPU,Central Puerto S.A. American Depositary Shares (each represents ten Common Shares),Central Puerto S.A. American Depositary Shares (each represents ten Common Shares),N,CEPU,N,100.0,N,CEPU
-CERY,SPDR Bloomberg Enhanced Roll Yield Commodity Strategy No K,SPDR Bloomberg Enhanced Roll Yield Commodity Strategy No K-1 ETF,P,CERY,Y,100.0,N,CERY
+CERY,State Street SPDR Bloomberg Enhanced Roll Yield Commodity Strategy No K,State Street SPDR Bloomberg Enhanced Roll Yield Commodity Strategy No K-1 ETF,P,CERY,Y,100.0,N,CERY
 CET,Central Securities Corporation Common Stock,Central Securities Corporation Common Stock,A,CET,N,100.0,N,CET
 CEV,Eaton Vance California Municipal Income Trust Shares of Beneficial Interest,Eaton Vance California Municipal Income Trust Shares of Beneficial Interest,A,CEV,N,100.0,N,CEV
 CEW,WisdomTree Emerging Currency Strategy Fund,WisdomTree Emerging Currency Strategy Fund,P,CEW,Y,100.0,N,CEW
@@ -1472,6 +1471,7 @@ DDFD,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Dire
 DDFF,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - February,Z,DDFF,Y,100.0,N,DDFF
 DDFJ,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - January,Z,DDFJ,Y,100.0,N,DDFJ
 DDFL,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - July,Z,DDFL,Y,100.0,N,DDFL
+DDFM,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - March,Z,DDFM,Y,100.0,N,DDFM
 DDFN,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - November,Z,DDFN,Y,100.0,N,DDFN
 DDFO,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - October,Z,DDFO,Y,100.0,N,DDFO
 DDFS,Innovator Equity Dual Directional 15 Buffer ETF ,Innovator Equity Dual Directional 15 Buffer ETF - September,Z,DDFS,Y,100.0,N,DDFS
@@ -1486,6 +1486,7 @@ DDTD,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Dire
 DDTF,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - February,Z,DDTF,Y,100.0,N,DDTF
 DDTJ,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - January,Z,DDTJ,Y,100.0,N,DDTJ
 DDTL,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - July,Z,DDTL,Y,100.0,N,DDTL
+DDTM,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - March,Z,DDTM,Y,100.0,N,DDTM
 DDTN,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - November,Z,DDTN,Y,100.0,N,DDTN
 DDTO,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - October,Z,DDTO,Y,100.0,N,DDTO
 DDTS,Innovator Equity Dual Directional 10 Buffer ETF ,Innovator Equity Dual Directional 10 Buffer ETF - September,Z,DDTS,Y,100.0,N,DDTS
@@ -1671,6 +1672,7 @@ DRIP,Direxion Daily S&P Oil & Gas Exp. & Prod. Bear 2X Shares,Direxion Daily S&P
 DRKY,VistaShares Target 15 DRUKMacro Distribution ETF,VistaShares Target 15 DRUKMacro Distribution ETF,P,DRKY,Y,100.0,N,DRKY
 DRLL,Strive U.S. Energy ETF,Strive U.S. Energy ETF,N,DRLL,Y,100.0,N,DRLL
 DRN,Direxion Daily Real Estate Bull 3X Shares,Direxion Daily Real Estate Bull 3X Shares,P,DRN,Y,100.0,N,DRN
+DRNL,Defiance 2X Daily Long Pure Drone and Aerial Automation ETF,Defiance 2X Daily Long Pure Drone and Aerial Automation ETF,Z,DRNL,Y,100.0,N,DRNL
 DRSK,Aptus Defined Risk ETF,Aptus Defined Risk ETF,Z,DRSK,Y,100.0,N,DRSK
 DRUP,GraniteShares Nasdaq Select Disruptors ETF,GraniteShares Nasdaq Select Disruptors ETF,P,DRUP,Y,100.0,N,DRUP
 DRV,Direxion Daily Real Estate Bear 3X Shares,Direxion Daily Real Estate Bear 3X Shares,P,DRV,Y,100.0,N,DRV
@@ -2396,7 +2398,6 @@ FR,"First Industrial Realty Trust, Inc. Common Stock","First Industrial Realty T
 FRA,Blackrock Floating Rate Income Strategies Fund Inc  Common Stock,Blackrock Floating Rate Income Strategies Fund Inc  Common Stock,N,FRA,N,100.0,N,FRA
 FRDM,Freedom 100 Emerging Markets ETF,Freedom 100 Emerging Markets ETF,Z,FRDM,Y,100.0,N,FRDM
 FREL,Fidelity MSCI Real Estate Index ETF,Fidelity MSCI Real Estate Index ETF,P,FREL,Y,100.0,N,FREL
-FRGE,"Forge Global Holdings, Inc. Common Stock","Forge Global Holdings, Inc. Common Stock",N,FRGE,N,100.0,N,FRGE
 FRGN,Horizon International Equity ETF,Horizon International Equity ETF,P,FRGN,Y,100.0,N,FRGN
 FRI,First Trust S&P REIT Index Fund,First Trust S&P REIT Index Fund,P,FRI,Y,100.0,N,FRI
 FRIZ,Franklin Dividend Growth ETF,Franklin Dividend Growth ETF,P,FRIZ,Y,100.0,N,FRIZ
@@ -2458,7 +2459,6 @@ FUBO,FuboTV Inc. Class A Common Stock,FuboTV Inc. Class A Common Stock,N,FUBO,N,
 FUL,H. B. Fuller Company Common Stock,H. B. Fuller Company Common Stock,N,FUL,N,100.0,N,FUL
 FUMB,First Trust Ultra Short Duration Municipal ETF,First Trust Ultra Short Duration Municipal ETF,P,FUMB,Y,100.0,N,FUMB
 FUN,Six Flags Entertainment Corporation Common Stock New,Six Flags Entertainment Corporation Common Stock New,N,FUN,N,100.0,N,FUN
-FUNL,CornerCap Fundametrics Large,CornerCap Fundametrics Large-Cap ETF,Z,FUNL,Y,100.0,N,FUNL
 FURY,Fury Gold Mines Limited Common Shares,Fury Gold Mines Limited Common Shares,A,FURY,N,100.0,N,FURY
 FUSI,American Century Multisector Floating Income ETF,American Century Multisector Floating Income ETF,P,FUSI,Y,100.0,N,FUSI
 FUTY,Fidelity MSCI Utilities Index ETF,Fidelity MSCI Utilities Index ETF,P,FUTY,Y,100.0,N,FUTY
@@ -2520,7 +2520,6 @@ GBTC,Grayscale Bitcoin Trust (BTC),Grayscale Bitcoin Trust (BTC),P,GBTC,Y,100.0,
 GBTG,"Global Business Travel Group, Inc. Class A Common Stock","Global Business Travel Group, Inc. Class A Common Stock",N,GBTG,N,100.0,N,GBTG
 GBX,"Greenbrier Companies, Inc. (The) Common Stock","Greenbrier Companies, Inc. (The) Common Stock",N,GBX,N,100.0,N,GBX
 GBXA,Goldman Sachs U.S. Large Cap Buffer 1 ETF,Goldman Sachs U.S. Large Cap Buffer 1 ETF,Z,GBXA,Y,100.0,N,GBXA
-GBXC,Goldman Sachs U.S. Large Cap Buffer 3 ETF,Goldman Sachs U.S. Large Cap Buffer 3 ETF,Z,GBXC,Y,100.0,N,GBXC
 GCAD,Gabelli Commercial Aerospace and Defense ETF,Gabelli Commercial Aerospace and Defense ETF,P,GCAD,Y,100.0,N,GCAD
 GCAL,Goldman Sachs Dynamic California Municipal Income ETF,Goldman Sachs Dynamic California Municipal Income ETF,P,GCAL,Y,100.0,N,GCAL
 GCC,WisdomTree EnhancedContinuous Commodity Index Fund,WisdomTree EnhancedContinuous Commodity Index Fund,P,GCC,Y,100.0,N,GCC
@@ -2628,6 +2627,7 @@ GLDG,GoldMining Inc. Common Shares,GoldMining Inc. Common Shares,A,GLDG,N,100.0,
 GLDM,SPDR Gold MiniShares Trust,SPDR Gold MiniShares Trust,P,GLDM,Y,100.0,N,GLDM
 GLDN,Nicholas Gold Income ETF,Nicholas Gold Income ETF,P,GLDN,Y,100.0,N,GLDN
 GLDW,Roundhill Gold WeeklyPay ETF,Roundhill Gold WeeklyPay ETF,Z,GLDW,Y,100.0,N,GLDW
+GLED.U,"GalaxyEdge Acquisition Corporation Units, each consisting of one Ordinary Share and one Right entitling the holder to receive 1/4th of one ordinary share","GalaxyEdge Acquisition Corporation Units, each consisting of one Ordinary Share and one Right entitling the holder to receive 1/4th of one ordinary share",N,GLED.U,N,100.0,N,GLED=
 GLIN,VanEck India Growth Leaders ETF,VanEck India Growth Leaders ETF,P,GLIN,Y,100.0,N,GLIN
 GLIX,Lazard Listed Infrastructure ETF,Lazard Listed Infrastructure ETF,P,GLIX,Y,100.0,N,GLIX
 GLL,ProShares UltraShort Gold,ProShares UltraShort Gold,P,GLL,Y,100.0,N,GLL
@@ -3116,7 +3116,7 @@ IFED,ETRACS IFED Invest with the Fed TR Index ETN,ETRACS IFED Invest with the Fe
 IFF,"International Flavors & Fragrances, Inc. Common Stock","International Flavors & Fragrances, Inc. Common Stock",N,IFF,N,100.0,N,IFF
 IFLN,Invesco Bloomberg Enhanced Fallen Angels ETF,Invesco Bloomberg Enhanced Fallen Angels ETF,P,IFLN,Y,100.0,N,IFLN
 IFLR,Innovator International Developed Managed Floor ETF,Innovator International Developed Managed Floor ETF,P,IFLR,Y,100.0,N,IFLR
-IFN,"India Fund, Inc. (The) Common Stock","India Fund, Inc. (The) Common Stock",N,IFN,N,100.0,N,IFN
+IFN,"Aberdeen India Fund, Inc. Common Stock","Aberdeen India Fund, Inc. Common Stock",N,IFN,N,100.0,N,IFN
 IFRA,iShares U.S. Infrastructure ETF,iShares U.S. Infrastructure ETF,Z,IFRA,Y,100.0,N,IFRA
 IFS,Intercorp Financial Services Inc. Common Shares,Intercorp Financial Services Inc. Common Shares,N,IFS,N,100.0,N,IFS
 IG,Principal Investment Grade Corporate Active ETF,Principal Investment Grade Corporate Active ETF,P,IG,Y,100.0,N,IG
@@ -3497,7 +3497,7 @@ JPM$L,"J P Morgan Chase & Co Depositary Shares, each representing a 1/400th inte
 JPM$M,"J P Morgan Chase & Co Depositary Shares, each representing a 1/400th interest in a share of 4.20% Non","J P Morgan Chase & Co Depositary Shares, each representing a 1/400th interest in a share of 4.20% Non-Cumulative Preferred Stock, Series MM",N,JPMpM,N,100.0,N,JPM-M
 JPMB,JPMorgan USD Emerging Markets Sovereign Bond ETF,JPMorgan USD Emerging Markets Sovereign Bond ETF,P,JPMB,Y,100.0,N,JPMB
 JPME,JPMorgan Diversified Return U.S. Mid Cap Equity ETF,JPMorgan Diversified Return U.S. Mid Cap Equity ETF,P,JPME,Y,100.0,N,JPME
-JPMO,YieldMax JPM Option Income Strategy ETF,YieldMax JPM Option Income Strategy ETF,P,JPMO,Y,100.0,N,JPMO
+JPO,YieldMax JP Option Income Strategy ETF,YieldMax JP Option Income Strategy ETF,P,JPO,Y,100.0,N,JPO
 JPRE,JPMorgan Realty Income ETF,JPMorgan Realty Income ETF,P,JPRE,Y,100.0,N,JPRE
 JPSE,JPMorgan Diversified Return U.S. Small Cap Equity ETF,JPMorgan Diversified Return U.S. Small Cap Equity ETF,P,JPSE,Y,100.0,N,JPSE
 JPST,JPMorgan Ultra,JPMorgan Ultra-Short Income ETF,P,JPST,Y,100.0,N,JPST
@@ -3549,6 +3549,7 @@ KBFR,Innovator U.S. Small Cap Managed 10 Buffer ETF,Innovator U.S. Small Cap Man
 KBH,KB Home Common Stock,KB Home Common Stock,N,KBH,N,100.0,N,KBH
 KBR,"KBR, Inc. Common Stock","KBR, Inc. Common Stock",N,KBR,N,100.0,N,KBR
 KBUF,KraneShares 90% KWEB Defined Outcome January 2027 ETF,KraneShares 90% KWEB Defined Outcome January 2027 ETF,P,KBUF,Y,100.0,N,KBUF
+KCAC.U,"Kensington Capital Acquisition Corp. VI Units, each consisting of one Class A ordinary share, one","Kensington Capital Acquisition Corp. VI Units, each consisting of one Class A ordinary share, one-quarter of one Class 1 redeemable warrant and three-quarters of one Class 2 redeemable warrant",N,KCAC.U,N,100.0,N,KCAC=
 KCAI,KraneShares China Alpha Index ETF,KraneShares China Alpha Index ETF,P,KCAI,Y,100.0,N,KCAI
 KCCA,KraneShares California Carbon Allowance Strategy ETF,KraneShares California Carbon Allowance Strategy ETF,P,KCCA,Y,100.0,N,KCCA
 KCE,State Street SPDR S&P Capital Markets ETF,State Street SPDR S&P Capital Markets ETF,P,KCE,Y,100.0,N,KCE
@@ -4233,8 +4234,8 @@ NBCE,Neuberger China Equity ETF,Neuberger China Equity ETF,P,NBCE,Y,100.0,N,NBCE
 NBCM,Neuberger Commodity Strategy ETF,Neuberger Commodity Strategy ETF,P,NBCM,Y,100.0,N,NBCM
 NBCR,Neuberger Core Equity ETF,Neuberger Core Equity ETF,P,NBCR,Y,100.0,N,NBCR
 NBDS,Neuberger Disrupters ETF,Neuberger Disrupters ETF,P,NBDS,Y,100.0,N,NBDS
-NBET,Neuberger Berman Energy Transition & Infrastructure ETF,Neuberger Berman Energy Transition & Infrastructure ETF,P,NBET,Y,100.0,N,NBET
-NBFC,Neuberger Berman Flexible Credit Income ETF,Neuberger Berman Flexible Credit Income ETF,P,NBFC,Y,100.0,N,NBFC
+NBET,Neuberger Energy Transition & Infrastructure ETF,Neuberger Energy Transition & Infrastructure ETF,P,NBET,Y,100.0,N,NBET
+NBFC,Neuberger Flexible Credit Income ETF,Neuberger Flexible Credit Income ETF,P,NBFC,Y,100.0,N,NBFC
 NBFR,Innovator Nasdaq,Innovator Nasdaq-100 Managed 10 Buffer ETF,P,NBFR,Y,100.0,N,NBFR
 NBGX,Neuberger Growth ETF,Neuberger Growth ETF,P,NBGX,Y,100.0,N,NBGX
 NBH,Neuberger Municipal Fund Inc. Common Stock,Neuberger Municipal Fund Inc. Common Stock,A,NBH,N,100.0,N,NBH
@@ -4243,9 +4244,9 @@ NBIZ,Tradr 2X Short NBIS Daily ETF,Tradr 2X Short NBIS Daily ETF,Z,NBIZ,Y,100.0,
 NBJP,Neuberger Japan Equity ETF,Neuberger Japan Equity ETF,P,NBJP,Y,100.0,N,NBJP
 NBOS,Neuberger Option Strategy ETF,Neuberger Option Strategy ETF,P,NBOS,Y,100.0,N,NBOS
 NBR,Nabors Industries Ltd.,Nabors Industries Ltd.,N,NBR,N,100.0,N,NBR
-NBSD,Neuberger Berman Short Duration Income ETF,Neuberger Berman Short Duration Income ETF,P,NBSD,Y,100.0,N,NBSD
+NBSD,Neuberger Short Duration Income ETF,Neuberger Short Duration Income ETF,P,NBSD,Y,100.0,N,NBSD
 NBSM,Neuberger Small,Neuberger Small-Mid Cap ETF,P,NBSM,Y,100.0,N,NBSM
-NBTR,Neuberger Berman Total Return Bond ETF,Neuberger Berman Total Return Bond ETF,P,NBTR,Y,100.0,N,NBTR
+NBTR,Neuberger Total Return Bond ETF,Neuberger Total Return Bond ETF,P,NBTR,Y,100.0,N,NBTR
 NBXG,Neuberger Next Generation Connectivity Fund Inc. Common Stock,Neuberger Next Generation Connectivity Fund Inc. Common Stock,N,NBXG,N,100.0,N,NBXG
 NBY,"NovaBay Pharmaceuticals, Inc. Common Stock","NovaBay Pharmaceuticals, Inc. Common Stock",A,NBY,N,100.0,N,NBY
 NC,"NACCO Industries, Inc. Common Stock","NACCO Industries, Inc. Common Stock",N,NC,N,100.0,N,NC
@@ -4278,7 +4279,7 @@ NEE$U,"NextEra Energy, Inc. Series U Junior Subordinated Debentures due June 1, 
 NEHI,NEOS Ethereum High Income ETF,NEOS Ethereum High Income ETF,Z,NEHI,Y,100.0,N,NEHI
 NELS,Nelson Select ETF,Nelson Select ETF,Z,NELS,Y,100.0,N,NELS
 NEM,Newmont Corporation,Newmont Corporation,N,NEM,N,100.0,N,NEM
-NEMD,Neuberger Berman Emerging Markets Debt Hard Currency ETF,Neuberger Berman Emerging Markets Debt Hard Currency ETF,P,NEMD,Y,100.0,N,NEMD
+NEMD,Neuberger Emerging Markets Debt Hard Currency ETF,Neuberger Emerging Markets Debt Hard Currency ETF,P,NEMD,Y,100.0,N,NEMD
 NEN,New England Realty Associates Limited Partnership Class A Depositary Receipts Evidencing Units of Limited Partnership,New England Realty Associates Limited Partnership Class A Depositary Receipts Evidencing Units of Limited Partnership,A,NEN,N,100.0,N,NEN
 NERD,Roundhill Video Games ETF,Roundhill Video Games ETF,Z,NERD,Y,100.0,N,NERD
 NET,"Cloudflare, Inc. Class A Common Stock","Cloudflare, Inc. Class A Common Stock",N,NET,N,100.0,N,NET
@@ -4424,6 +4425,7 @@ NUEM,Nuveen ESG Emerging Markets Equity ETF,Nuveen ESG Emerging Markets Equity E
 NUGO,Nuveen Growth Opportunities ETF,Nuveen Growth Opportunities ETF,P,NUGO,Y,100.0,N,NUGO
 NUGT,Direxion Daily Gold Miners Index Bull 2XShares,Direxion Daily Gold Miners Index Bull 2XShares,P,NUGT,Y,100.0,N,NUGT
 NUHY,Nuveen ESG High Yield Corporate Bond ETF,Nuveen ESG High Yield Corporate Bond ETF,P,NUHY,Y,100.0,N,NUHY
+NUKX,Nicholas Nuclear Income ETF,Nicholas Nuclear Income ETF,P,NUKX,Y,100.0,N,NUKX
 NUKZ,Range Nuclear Renaissance Index ETF,Range Nuclear Renaissance Index ETF,P,NUKZ,Y,100.0,N,NUKZ
 NULC,Nuveen ESG Large,Nuveen ESG Large-Cap ETF,Z,NULC,Y,100.0,N,NULC
 NULG,Nuveen ESG Large,Nuveen ESG Large-Cap Growth ETF,Z,NULG,Y,100.0,N,NULG
@@ -4887,6 +4889,7 @@ PPEM,Putnam PanAgora ESG Emerging Markets Equity ETF,Putnam PanAgora ESG Emergin
 PPG,"PPG Industries, Inc. Common Stock","PPG Industries, Inc. Common Stock",N,PPG,N,100.0,N,PPG
 PPIE,Putnam PanAgora ESG International Equity ETF,Putnam PanAgora ESG International Equity ETF,P,PPIE,Y,100.0,N,PPIE
 PPL,PPL Corporation Common Stock,PPL Corporation Common Stock,N,PPL,N,100.0,N,PPL
+PPLC,PPL Corporation Corporate Units,PPL Corporation Corporate Units,N,PPLC,N,100.0,N,PPLC
 PPLT,abrdn Physical Platinum Shares ETF,abrdn Physical Platinum Shares ETF,P,PPLT,Y,100.0,N,PPLT
 PPT,Putnam Premier Income Trust Common Stock,Putnam Premier Income Trust Common Stock,N,PPT,N,100.0,N,PPT
 PPTY,U.S. Diversified Real Estate ETF,U.S. Diversified Real Estate ETF,P,PPTY,Y,100.0,N,PPTY
@@ -4910,7 +4913,7 @@ PRIF$J,"Priority Income Fund, Inc. 6.000% Series J Term Preferred Stock due 2028
 PRIF$K,"Priority Income Fund, Inc. 7.000% Series K Cumulative Preferred Stock","Priority Income Fund, Inc. 7.000% Series K Cumulative Preferred Stock",N,PRIFpK,N,100.0,N,PRIF-K
 PRIF$L,"Priority Income Fund, Inc. 6.375% Series L Term Preferred Stock Due 2029","Priority Income Fund, Inc. 6.375% Series L Term Preferred Stock Due 2029",N,PRIFpL,N,100.0,N,PRIF-L
 PRIM,Primoris Services Corporation Common Stock,Primoris Services Corporation Common Stock,N,PRIM,N,100.0,N,PRIM
-PRIV,SPDR SSGA IG Public & Private Credit ETF,SPDR SSGA IG Public & Private Credit ETF,P,PRIV,Y,100.0,N,PRIV
+PRIV,State Street IG Public & Private Credit ETF,State Street IG Public & Private Credit ETF,P,PRIV,Y,100.0,N,PRIV
 PRK,Park National Corporation Common Stock,Park National Corporation Common Stock,A,PRK,N,100.0,N,PRK
 PRKS,United Parks & Resorts Inc. Common Stock,United Parks & Resorts Inc. Common Stock,N,PRKS,N,100.0,N,PRKS
 PRLB,"Proto Labs, Inc. Common stock","Proto Labs, Inc. Common stock",N,PRLB,N,100.0,N,PRLB
@@ -5127,7 +5130,6 @@ RBLD,First Trust Alerian US NextGen Infrastructure ETF,First Trust Alerian US Ne
 RBLU,T,T-REX 2X Long RBLX Daily Target ETF,Z,RBLU,Y,100.0,N,RBLU
 RBLX,Roblox Corporation Class A Common Stock,Roblox Corporation Class A Common Stock,N,RBLX,N,100.0,N,RBLX
 RBLY,YieldMax RBLX Option Income Strategy ETF,YieldMax RBLX Option Income Strategy ETF,P,RBLY,Y,100.0,N,RBLY
-RBOT,Vicarious Surgical Inc. Class A Common Stock,Vicarious Surgical Inc. Class A Common Stock,N,RBOT,N,100.0,N,RBOT
 RBRK,"Rubrik, Inc. Class A Common Stock","Rubrik, Inc. Class A Common Stock",N,RBRK,N,100.0,N,RBRK
 RBUF,Innovator U.S. Small Cap 10 Buffer ETF ,Innovator U.S. Small Cap 10 Buffer ETF - Quarterly,Z,RBUF,Y,100.0,N,RBUF
 RC,Ready Capital Corporation Common Stock,Ready Capital Corporation Common Stock,N,RC,N,100.0,N,RC
@@ -5391,6 +5393,7 @@ SAP,SAP  SE ADS,SAP  SE ADS,N,SAP,N,40.0,N,SAP
 SAPH,SAP SE ADRhedged,SAP SE ADRhedged,P,SAPH,Y,100.0,N,SAPH
 SAR,Saratoga Investment Corp New,Saratoga Investment Corp New,N,SAR,N,100.0,N,SAR
 SARO,"StandardAero, Inc. Common Stock","StandardAero, Inc. Common Stock",N,SARO,N,100.0,N,SARO
+SASS,M.D. Sass Concentrated Value ETF,M.D. Sass Concentrated Value ETF,P,SASS,Y,100.0,N,SASS
 SAT,Saratoga Investment Corp 6.00% Notes due 2027,Saratoga Investment Corp 6.00% Notes due 2027,N,SAT,N,100.0,N,SAT
 SATO,Invesco Alerian Galaxy Crypto Economy ETF,Invesco Alerian Galaxy Crypto Economy ETF,Z,SATO,Y,100.0,N,SATO
 SAUG,FT Vest U.S. Small Cap Moderate Buffer ETF ,FT Vest U.S. Small Cap Moderate Buffer ETF - August,Z,SAUG,Y,100.0,N,SAUG
@@ -5580,9 +5583,9 @@ SHYM,iShares Short Duration High Yield Muni Active ETF,iShares Short Duration Hi
 SI,"Shoulder Innovations, Inc. Common Stock","Shoulder Innovations, Inc. Common Stock",N,SI,N,100.0,N,SI
 SID,Companhia Siderurgica Nacional S.A. Common Stock,Companhia Siderurgica Nacional S.A. Common Stock,N,SID,N,100.0,N,SID
 SIF,"SIFCO Industries, Inc. Common Stock","SIFCO Industries, Inc. Common Stock",A,SIF,N,100.0,N,SIF
-SIFI,Harbor Scientific Alpha Income ETF,Harbor Scientific Alpha Income ETF,P,SIFI,Y,100.0,N,SIFI
+SIFI,Harbor Ares Systematic Multi,Harbor Ares Systematic Multi-Sector Income ETF,P,SIFI,Y,100.0,N,SIFI
 SIG,Signet Jewelers Limited Common Shares,Signet Jewelers Limited Common Shares,N,SIG,N,100.0,N,SIG
-SIHY,Harbor Scientific Alpha High,Harbor Scientific Alpha High-Yield ETF,P,SIHY,Y,100.0,N,SIHY
+SIHY,Harbor Ares Systematic High Yield ETF,Harbor Ares Systematic High Yield ETF,P,SIHY,Y,100.0,N,SIHY
 SII,Sprott Inc. Common Shares,Sprott Inc. Common Shares,N,SII,N,100.0,N,SII
 SIJ,ProShares UltraShort Industrials,ProShares UltraShort Industrials,P,SIJ,Y,100.0,N,SIJ
 SIL,Global X Silver Miners ETF,Global X Silver Miners ETF,P,SIL,Y,100.0,N,SIL
@@ -5627,7 +5630,7 @@ SLG,SL Green Realty Corp Common Stock,SL Green Realty Corp Common Stock,N,SLG,N,
 SLG$I,SL Green Realty Corporation Preferred Series I,SL Green Realty Corporation Preferred Series I,N,SLGpI,N,100.0,N,SLG-I
 SLGN,Silgan Holdings Inc. Common Stock,Silgan Holdings Inc. Common Stock,N,SLGN,N,100.0,N,SLGN
 SLI,Standard Lithium Ltd. Common Shares,Standard Lithium Ltd. Common Shares,A,SLI,N,100.0,N,SLI
-SLJY,Amplify SILJ Covered Call ETF,Amplify SILJ Covered Call ETF,P,SLJY,Y,100.0,N,SLJY
+SLJY,Amplify SILJ Junior Silver Miners Covered Call ETF,Amplify SILJ Junior Silver Miners Covered Call ETF,P,SLJY,Y,100.0,N,SLJY
 SLND,"Southland Holdings, Inc. Common Stock","Southland Holdings, Inc. Common Stock",A,SLND,N,100.0,N,SLND
 SLND.W,"Southland Holdings, Inc. Warrants","Southland Holdings, Inc. Warrants",A,SLND.WS,N,100.0,N,SLND+
 SLNZ,TCW Senior Loan ETF,TCW Senior Loan ETF,N,SLNZ,Y,100.0,N,SLNZ
@@ -5892,6 +5895,7 @@ SU,Suncor Energy  Inc. Common Stock,Suncor Energy  Inc. Common Stock,N,SU,N,100.
 SUB,iShares Short,iShares Short-Term National Muni Bond ETF,P,SUB,Y,100.0,N,SUB
 SUI,"Sun Communities, Inc. Common Stock","Sun Communities, Inc. Common Stock",N,SUI,N,100.0,N,SUI
 SUN,Sunoco LP Common Units representing limited partner interests,Sunoco LP Common Units representing limited partner interests,N,SUN,N,100.0,N,SUN
+SUNB,"Sunbelt Rentals Holdings, Inc. Common Stock","Sunbelt Rentals Holdings, Inc. Common Stock",N,SUNB,N,100.0,N,SUNB
 SUNC,"SunocoCorp LLC Common Units, representing limited liability company interests","SunocoCorp LLC Common Units, representing limited liability company interests",N,SUNC,N,100.0,N,SUNC
 SUPL,ProShares Supply Chain Logistics ETF,ProShares Supply Chain Logistics ETF,P,SUPL,Y,100.0,N,SUPL
 SUPV,Grupo Supervielle S.A. American Depositary Shares each Representing five Class B shares,Grupo Supervielle S.A. American Depositary Shares each Representing five Class B shares,N,SUPV,N,100.0,N,SUPV
@@ -6207,7 +6211,6 @@ TRV,"The Travelers Companies, Inc. Common Stock","The Travelers Companies, Inc. 
 TRX,TRX Gold Corporation Common Stock,TRX Gold Corporation Common Stock,A,TRX,N,100.0,N,TRX
 TS,Tenaris S.A. American Depositary Shares,Tenaris S.A. American Depositary Shares,N,TS,N,100.0,N,TS
 TSCV,Thrivent Small Cap Value ETF,Thrivent Small Cap Value ETF,P,TSCV,Y,100.0,N,TSCV
-TSE,Trinseo PLC Ordinary Shares ,Trinseo PLC Ordinary Shares ,N,TSE,N,100.0,N,TSE
 TSEC,Touchstone Securitized Income ETF,Touchstone Securitized Income ETF,P,TSEC,Y,100.0,N,TSEC
 TSEP,FT Vest Emerging Market Buffer ETF ,FT Vest Emerging Market Buffer ETF - September,Z,TSEP,Y,100.0,N,TSEP
 TSES,Truth Social American Energy Security ETF,Truth Social American Energy Security ETF,P,TSES,Y,100.0,N,TSES
@@ -6377,7 +6380,7 @@ URTH,iShares MSCI World ETF,iShares MSCI World ETF,P,URTH,Y,100.0,N,URTH
 URTY,ProShares UltraPro Russell2000,ProShares UltraPro Russell2000,P,URTY,Y,100.0,N,URTY
 USA,Liberty All,Liberty All-Star Equity Fund Common Stock,N,USA,N,100.0,N,USA
 USAC,"USA Compression Partners, LP Common Units Representing Limited Partner Interests","USA Compression Partners, LP Common Units Representing Limited Partner Interests",N,USAC,N,100.0,N,USAC
-USAI,Pacer American Energy Independence ETF,Pacer American Energy Independence ETF,P,USAI,Y,100.0,N,USAI
+USAI,Pacer American Energy Infrastructure ETF,Pacer American Energy Infrastructure ETF,P,USAI,Y,100.0,N,USAI
 USAS,"Americas Gold and Silver Corporation Common Shares, no par value","Americas Gold and Silver Corporation Common Shares, no par value",A,USAS,N,100.0,N,USAS
 USAX,Tradr 2X Long USAR Daily ETF,Tradr 2X Long USAR Daily ETF,Z,USAX,Y,100.0,N,USAX
 USB,U.S. Bancorp Common Stock,U.S. Bancorp Common Stock,N,USB,N,100.0,N,USB
@@ -6401,6 +6404,7 @@ USFR,WisdomTree Floating Rate Treasury Fund,WisdomTree Floating Rate Treasury Fu
 USG,USCF Gold Strategy Plus Income Fund,USCF Gold Strategy Plus Income Fund,P,USG,Y,100.0,N,USG
 USHY,iShares Broad USD High Yield Corporate Bond ETF,iShares Broad USD High Yield Corporate Bond ETF,Z,USHY,Y,100.0,N,USHY
 USL,United States 12 Month Oil,United States 12 Month Oil,P,USL,Y,100.0,N,USL
+USLN,iShares Broad USD Floating Rate Loan ETF,iShares Broad USD Floating Rate Loan ETF,Z,USLN,Y,100.0,N,USLN
 USMD,CoreValues America First Technology ETF,CoreValues America First Technology ETF,P,USMD,Y,100.0,N,USMD
 USMF,WisdomTree U.S. Multifactor Fund,WisdomTree U.S. Multifactor Fund,Z,USMF,Y,100.0,N,USMF
 USML,ETRACS 2x Leveraged MSCI US Minimum Volatility Factor TR ETN,ETRACS 2x Leveraged MSCI US Minimum Volatility Factor TR ETN,P,USML,Y,100.0,N,USML
@@ -6664,6 +6668,7 @@ WEED,Roundhill Cannabis ETF,Roundhill Cannabis ETF,Z,WEED,Y,100.0,N,WEED
 WEEK,Roundhill Weekly T,Roundhill Weekly T-Bill ETF,Z,WEEK,Y,100.0,N,WEEK
 WEEL,Peerless Option Income Wheel ETF,Peerless Option Income Wheel ETF,P,WEEL,Y,100.0,N,WEEL
 WELL,Welltower Inc. Common Stock,Welltower Inc. Common Stock,N,WELL,N,100.0,N,WELL
+WEPN,Nicholas Defense and Rare Earth Income ETF,Nicholas Defense and Rare Earth Income ETF,P,WEPN,Y,100.0,N,WEPN
 WES,"Western Midstream Partners, LP Common Units Representing Limited Partner Interests","Western Midstream Partners, LP Common Units Representing Limited Partner Interests",N,WES,N,100.0,N,WES
 WEX,WEX Inc. common stock,WEX Inc. common stock,N,WEX,N,100.0,N,WEX
 WF,Woori Financial Group Inc. American Depositary Shares (each representing three (3) shares of Common Stock),Woori Financial Group Inc. American Depositary Shares (each representing three (3) shares of Common Stock),N,WF,N,100.0,N,WF
@@ -6680,6 +6685,7 @@ WH,"Wyndham Hotels & Resorts, Inc. Common Stock ","Wyndham Hotels & Resorts, Inc
 WHD,"Cactus, Inc. Class A Common Stock","Cactus, Inc. Class A Common Stock",N,WHD,N,100.0,N,WHD
 WHG,Westwood Holdings Group Inc Common Stock,Westwood Holdings Group Inc Common Stock,N,WHG,N,100.0,N,WHG
 WHR,Whirlpool Corporation Common Stock,Whirlpool Corporation Common Stock,N,WHR,N,100.0,N,WHR
+WHR$A,"Whirlpool Corporation Depositary Shares, each representing a 1/20th interest in a share of 8.50% Series A Mandatory Convertible Preferred Stock","Whirlpool Corporation Depositary Shares, each representing a 1/20th interest in a share of 8.50% Series A Mandatory Convertible Preferred Stock",N,WHRpA,N,100.0,N,WHR-A
 WIA,Western Asset Inflation,Western Asset Inflation-Linked Income Fund,N,WIA,N,100.0,N,WIA
 WINN,Harbor Long,Harbor Long-Term Growers ETF,N,WINN,Y,100.0,N,WINN
 WIP,SPDR FTSE International Government Inflation,SPDR FTSE International Government Inflation-Protected Bond ETF,P,WIP,Y,100.0,N,WIP
@@ -6866,7 +6872,7 @@ XRN$A,Chiron Real Estate Inc. Series A Cumulative Redeemable Preferred Stock,Chi
 XRN$B,"Chiron Real Estate Inc. 8.00% Series B Cumulative Redeemable Preferred Stock, $0.001 par value per share","Chiron Real Estate Inc. 8.00% Series B Cumulative Redeemable Preferred Stock, $0.001 par value per share",N,XRNpB,N,100.0,N,XRN-B
 XRP,Bitwise XRP ETF,Bitwise XRP ETF,P,XRP,Y,100.0,N,XRP
 XRPK,T,T-REX 2X Long XRP Daily Target ETF,Z,XRPK,Y,100.0,N,XRPK
-XRPM,Amplify XRP 3% Monthly Premium Income ETF,Amplify XRP 3% Monthly Premium Income ETF,Z,XRPM,Y,100.0,N,XRPM
+XRPM,Amplify XRP 3% Monthly Option Income ETF,Amplify XRP 3% Monthly Option Income ETF,Z,XRPM,Y,100.0,N,XRPM
 XRPR,REX,REX-Osprey XRP ETF,Z,XRPR,Y,100.0,N,XRPR
 XRPZ,Franklin XRP ETF,Franklin XRP ETF,P,XRPZ,Y,100.0,N,XRPZ
 XRT,State Street SPDR S&P Retail ETF,State Street SPDR S&P Retail ETF,P,XRT,Y,100.0,N,XRT

--- a/datapackage.json
+++ b/datapackage.json
@@ -12,12 +12,12 @@
                     {
                         "description": "",
                         "name": "ACT Symbol",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "Company Name",
-                        "type": "string"
+                        "type": "number"
                     }
                 ]
             }
@@ -32,32 +32,32 @@
                     {
                         "description": "",
                         "name": "ACT Symbol",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "Company Name",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "Security Name",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "Exchange",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "CQS Symbol",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "ETF",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
@@ -67,12 +67,12 @@
                     {
                         "description": "",
                         "name": "Test Issue",
-                        "type": "string"
+                        "type": "number"
                     },
                     {
                         "description": "",
                         "name": "NASDAQ Symbol",
-                        "type": "string"
+                        "type": "number"
                     }
                 ]
             }


### PR DESCRIPTION
## Summary
- rerun listings ingestion from Nasdaq symbol directory and refresh `other-listed`/`nyse-listed` outputs with updated datapackage metadata
- modernize workflow automation with explicit write permissions and current action versions while keeping scheduled/manual updates
- add a root maintenance report documenting script execution and CI hardening changes